### PR TITLE
Fix webGUI port

### DIFF
--- a/mgutt/Apache-WebDAV.xml
+++ b/mgutt/Apache-WebDAV.xml
@@ -29,7 +29,7 @@ or this if you choosed "Digest" authentification:&#xD;
 &#xD;
 Execute the command multiple times with different usernames to add more users.</Overview>
   <Category>Cloud:</Category>
-  <WebUI>http://[IP]:[PORT:8384]/</WebUI>
+  <WebUI>http://[IP]:[PORT:80]/</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/mgutt/unraid-docker-templates/main/mgutt/Apache-WebDAV.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/mgutt/unraid-docker-templates/main/mgutt/images/webdav-powered-by-apache.png</Icon>
   <ExtraParams>--memory=1G</ExtraParams>


### PR DESCRIPTION
The Port # [IP]:[PORT] always refers to the container port.  This allows the docker system to see what port (80) is mapped to (8384) and have the URL automatically updated if the user changes the host port.  While yours does work, if the user changes the host port to something else more suitable to them then they also have to switch to advanced view and change the port # in the webGUI